### PR TITLE
Resize iframe to fit content up to 600px

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
+dist: trusty
 language: node_js
 node_js: node
+addons:
+  chrome: stable
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start

--- a/demo_frame.js
+++ b/demo_frame.js
@@ -40,6 +40,7 @@ module.exports = function(node) {
 			show(node.querySelector("[data-tab=js]"));
 		}
 
+		resizeIframe();
 		tabs();
 	}
 
@@ -130,5 +131,31 @@ module.exports = function(node) {
 	function prettyify(txt) {
 		txt = txt.replace(/</g, "&lt;");
 		return typeof prettyPrintOne !== "undefined" ? prettyPrintOne(txt) : txt;
+	}
+
+	function resizeIframe() {
+		var frame = node.getElementsByTagName("iframe")[0];
+		var height = frame.contentWindow.document.body.scrollHeight;
+
+		var tolerance = 5; // pixels
+		var low = height - tolerance;
+		var high = height + tolerance;
+
+		// turns "150px" to 150, and "" to 0
+		var getCssHeight = function() {
+			var h = frame.style.height;
+			return Number(h.substr(0, h.length - 2) || 0);
+		};
+
+		var cssHeight = getCssHeight();
+
+		// Setting the height causes the next resizeIframe call to get a different
+		// height reading (lower); The range/tolerance logic is added to prevent the
+		// continous shrinking of the iframe
+		if (cssHeight < low || cssHeight > high) {
+			iframe.style.height = Math.min(high, 600) + "px";
+		}
+
+		setTimeout(resizeIframe, 1000);
 	}
 };

--- a/demo_frame.js
+++ b/demo_frame.js
@@ -1,23 +1,13 @@
-var template = '<ul>' +
-		'<li class="tab" data-tab="demo">Demo</li>' +
-		'<li class="tab" data-tab="html">HTML</li>' +
-		'<li class="tab" data-tab="js" style="display:none;">JS</li>' +
-	'</ul>' +
-	'<div class="tab-content" data-for="demo">' +
-		'<iframe></iframe>' +
-	'</div>' +
-	'<div class="tab-content" data-for="html">' +
-		'<pre class="prettyprint"></pre>' +
-	'</div>' +
-	'<div class="tab-content" data-for="js">' +
-		'<pre class="prettyprint lang-js"></pre>' +
-	'</div>';
+var template = require("./demo_tpl");
 
-function render(node, docObject){
+function render(node, docObject) {
 	var demoDiv = document.createElement("div");
 	demoDiv.className = "demo";
 	demoDiv.innerHTML = template;
-	var demoSrc = (docObject.pathToRoot || "..") + "/" + (node.dataset ? node.dataset.demoSrc : node.getAttribute("data-demo-src"));
+	var demoSrc =
+		(docObject.pathToRoot || "..") +
+		"/" +
+		(node.dataset ? node.dataset.demoSrc : node.getAttribute("data-demo-src"));
 	demoDiv.getElementsByTagName("iframe")[0].src = demoSrc;
 
 	node.innerHTML = "";
@@ -26,8 +16,7 @@ function render(node, docObject){
 	return demoDiv;
 }
 
-
-module.exports = function(node){
+module.exports = function(node) {
 	var docObject = window.docObject || {};
 	render(node, docObject);
 
@@ -35,60 +24,64 @@ module.exports = function(node){
 
 	iframe.addEventListener("load", process);
 
-	function process(){
-			var demoEl = this.contentDocument.getElementById('demo-html'),
-				sourceEl = this.contentDocument.getElementById('demo-source');
+	function process() {
+		var demoEl = this.contentDocument.getElementById("demo-html"),
+			sourceEl = this.contentDocument.getElementById("demo-source");
 
-			var html = getHTML.call(this, demoEl);
-			var js = getJS.call(this, sourceEl);
+		var html = getHTML.call(this, demoEl);
+		var js = getJS.call(this, sourceEl);
 
-			var dataForHtml = node.querySelector("[data-for=html] > pre");
-			dataForHtml.innerHTML = prettyify(html);
+		var dataForHtml = node.querySelector("[data-for=html] > pre");
+		dataForHtml.innerHTML = prettyify(html);
 
-			if (js) {
-				var dataForJS = node.querySelector("[data-for=js] > pre");
-				dataForJS.innerHTML = prettyify(js.replace(/\t/g,"  "));
-				show(node.querySelector("[data-tab=js]"));
-			}
+		if (js) {
+			var dataForJS = node.querySelector("[data-for=js] > pre");
+			dataForJS.innerHTML = prettyify(js.replace(/\t/g, "  "));
+			show(node.querySelector("[data-tab=js]"));
+		}
 
-			tabs();
+		tabs();
 	}
 
 	function getHTML(demoEl) {
-			var html = demoEl ? demoEl.innerHTML : this.contentWindow.DEMO_HTML;
+		var html = demoEl ? demoEl.innerHTML : this.contentWindow.DEMO_HTML;
 
-			if(!html) {
-				// try to make from body
-				var clonedBody = this.contentDocument.body.cloneNode(true);
-				var scripts = [].slice.call(clonedBody.getElementsByTagName("script"));
-				scripts.forEach(function(script){
-					if(!script.type || script.type.indexOf("javascript") === -1) {
-						script.parentNode.removeChild(script);
-					}
-				});
-				var styles = [].slice.call(clonedBody.getElementsByTagName("style"));
-				styles.forEach(function(style){
-					style.parentNode.removeChild(style);
-				});
-				html = clonedBody.innerHTML;
-			}
-			return html;
+		if (!html) {
+			// try to make from body
+			var clonedBody = this.contentDocument.body.cloneNode(true);
+			var scripts = [].slice.call(clonedBody.getElementsByTagName("script"));
+			scripts.forEach(function(script) {
+				if (!script.type || script.type.indexOf("javascript") === -1) {
+					script.parentNode.removeChild(script);
+				}
+			});
+			var styles = [].slice.call(clonedBody.getElementsByTagName("style"));
+			styles.forEach(function(style) {
+				style.parentNode.removeChild(style);
+			});
+			html = clonedBody.innerHTML;
+		}
+		return html;
 	}
 
-	function getJS(sourceEl){
-			var source = sourceEl ? sourceEl.innerHTML : this.contentWindow.DEMO_SOURCE;
-			if(!source){
-				var scripts = [].slice.call(this.contentDocument.querySelectorAll("script"));
-				// get the first one that is JS
-				for(var i =0; i < scripts.length; i++){
-					if(!scripts[i].type || (scripts[i].type.indexOf("javascript") >= 0 &&
-						!scripts[i].src)){
-						source =  scripts[i].innerHTML;
-						break;
-					}
+	function getJS(sourceEl) {
+		var source = sourceEl ? sourceEl.innerHTML : this.contentWindow.DEMO_SOURCE;
+		if (!source) {
+			var scripts = [].slice.call(
+				this.contentDocument.querySelectorAll("script")
+			);
+			// get the first one that is JS
+			for (var i = 0; i < scripts.length; i++) {
+				if (
+					!scripts[i].type ||
+					(scripts[i].type.indexOf("javascript") >= 0 && !scripts[i].src)
+				) {
+					source = scripts[i].innerHTML;
+					break;
 				}
 			}
-			return (source ? source.trim() : '');
+		}
+		return source ? source.trim() : "";
 	}
 
 	function show(el) {
@@ -100,32 +93,30 @@ module.exports = function(node){
 	}
 
 	function tabs() {
-		node.querySelector("ul").addEventListener("click", function(ev){
+		node.querySelector("ul").addEventListener("click", function(ev) {
 			var el = ev.target;
-			if(el.className === "tab") {
+			if (el.className === "tab") {
 				toggle(el.dataset ? el.dataset.tab : el.getAttribute("data-tab"));
 			}
 		});
 		toggle("demo");
 
 		function toggle(tabName) {
-			each(".tab", function(el){
-				if(el.classList) {
+			each(".tab", function(el) {
+				if (el.classList) {
 					el.classList.remove("active");
 				} else {
 					el.className = "tab";
 				}
-
 			});
 
 			each(".tab-content", hide);
-			each(".tab[data-tab='" + tabName + "']", function(el){
-				if(el.classList) {
+			each(".tab[data-tab='" + tabName + "']", function(el) {
+				if (el.classList) {
 					el.classList.add("active");
 				} else {
 					el.className = "tab active";
 				}
-
 			});
 			each("[data-for='" + tabName + "']", show);
 		}
@@ -134,13 +125,10 @@ module.exports = function(node){
 			var tabs = [].slice.call(node.querySelectorAll(selector));
 			tabs.forEach(cb);
 		}
-
 	}
 
-	function prettyify(txt){
-		txt = txt.replace(/</g, '&lt;');
-		return typeof prettyPrintOne !== "undefined" ?
-			prettyPrintOne(txt) : txt;
+	function prettyify(txt) {
+		txt = txt.replace(/</g, "&lt;");
+		return typeof prettyPrintOne !== "undefined" ? prettyPrintOne(txt) : txt;
 	}
-
 };

--- a/demo_tpl.js
+++ b/demo_tpl.js
@@ -1,0 +1,16 @@
+module.exports = `
+	<ul>
+		<li class="tab" data-tab="demo">Demo</li>
+		<li class="tab" data-tab="html">HTML</li>
+		<li class="tab" data-tab="js" style="display:none;">JS</li>
+	</ul>
+	<div class="tab-content" data-for="demo">
+		<iframe></iframe>
+	</div>
+	<div class="tab-content" data-for="html">
+		<pre class="prettyprint"></pre>
+	</div>
+	<div class="tab-content" data-for="js">
+		<pre class="prettyprint lang-js"></pre>
+	</div>
+`;

--- a/package.json
+++ b/package.json
@@ -17,23 +17,23 @@
     "url": "git+ssh://git@github.com/bit-docs/bit-docs-tag-demo.git"
   },
   "scripts": {
+    "generate": "node test/generate",
+    "preversion": "npm test",
+    "postversion": "git push --tags && git push",
     "release:major": "npm version major && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:patch": "npm version patch && npm publish",
     "release:pre": "npm version prerelease && npm publish",
-    "test": "mocha test.js --reporter spec",
-    "preversion": "npm test",
-    "postversion": "git push --tags && git push"
+    "test": "npm run generate && mocha test.js"
   },
   "devDependencies": {
     "bit-docs-generate-html": "0.5.0-pre.4",
     "can-stache": "3.7.2",
-    "express": "^4.15.2",
+    "express": "^4.16.2",
     "mocha": "^3.2.0",
-    "rimraf": "^2.6.1",
+    "puppeteer": "^0.13.0",
     "steal": "^1.4.6",
-    "steal-less": "^1.2.0",
-    "zombie": "^5.0.5"
+    "steal-less": "^1.2.0"
   },
   "steal": {
     "plugins": [

--- a/test.js
+++ b/test.js
@@ -359,6 +359,33 @@ describe("bit-docs-tag-demo", function() {
 			});
 		});
 
+		describe("resize iframe to fit content up to 600px", function() {
+			before(function() {
+				return ctx.browser
+					.newPage()
+					.then(function(p) {
+						ctx.page = p;
+						return ctx.page.goto("http://127.0.0.1:8081/test/temp/height.html");
+					})
+					.then(function() {
+						return ctx.page.waitForFunction(function() {
+							var iframe = document.querySelector("iframe");
+							return iframe && iframe.style.height === "600px";
+						});
+					});
+			});
+
+			it("resizes height up to 600px", function() {
+				ctx.page
+					.evaluate(function() {
+						return document.querySelector("iframe").style.height;
+					})
+					.then(function(height) {
+						assert.equal(height, "600px");
+					});
+			});
+		});
+
 		describe("multiple instances", function() {
 			this.timeout(8000);
 
@@ -391,8 +418,8 @@ describe("bit-docs-tag-demo", function() {
 						};
 					})
 					.then(function(r) {
-						assert.equal(r.wrappers, 4, "four wrappers exists");
-						assert.equal(r.injected, 4, "four injected into wrappers");
+						assert.equal(r.wrappers, 5, "four wrappers exists");
+						assert.equal(r.injected, 5, "four injected into wrappers");
 					});
 			});
 		});

--- a/test.js
+++ b/test.js
@@ -1,310 +1,400 @@
-var Browser = require('zombie');
-var assert = require('assert');
-var express = require('express');
-var generate = require('bit-docs-generate-html/generate');
-var path = require('path');
-var rmrf = require('rimraf');
+var assert = require("assert");
+var express = require("express");
+var puppeteer = require("puppeteer");
 
-Browser.localhost('*.example.com', 3003);
-
-/*
- * Debug options:
- *	npm --debug test
- *	npm --devBuild test
- *	npm --skipGenerate test
- *	npm --debug --devBuild test
- *	npm --debug --skipGenerate test
- */
-
-describe('bit-docs-tag-demo', function () {
-	var browser = new Browser();
+describe("bit-docs-tag-demo", function() {
+	var ctx = this;
 	var server = express();
-	var temp = path.join(__dirname, 'test', 'temp');
 
-	before(function () {
-		if (!!process.env.npm_config_debug) {
-			browser.debug();
-		}
-
-		return new Promise(function (resolve, reject) {
-			server = server.use('/', express.static(__dirname)).listen(3003, resolve);
-			server.on('error', reject);
+	before(function() {
+		var serverPromise = new Promise(function(resolve, reject) {
+			server = server.use("/", express.static(__dirname)).listen(8081, resolve);
+			server.on("error", reject);
 		});
+
+		var puppeteerPromise = puppeteer.launch().then(function(b) {
+			ctx.browser = b;
+		});
+
+		return Promise.all([serverPromise, puppeteerPromise]);
 	});
 
-	describe('temp directory', function () {
-		before(function (done) {
-			if (!!process.env.npm_config_skipGenerate) {
-				this.skip();
-			}
-
-			rmrf(temp, done);
-		});
-
-		it('is generated', function () {
-			this.timeout(60000);
-
-			function demo_wrapper(path) {
-				return '<div class="demo_wrapper" data-demo-src="demos/' + path + '.html"></div>' + "\n"
-			}
-
-			function all_demos() {
-				return [
-					'demo-with-ids',
-					'demo-without-ids',
-					'demo-without-js',
-					'demo-complex'
-				].map(function (demo) {
-					return '<h2>' + demo + '</h2>' + demo_wrapper(demo);
-				}).join('<br>');
-			}
-
-			var docMap = Promise.resolve({
-				withIds: {
-					name: 'withIds',
-					body: demo_wrapper('demo-with-ids')
-				}, withoutIds: {
-					name: 'withoutIds',
-					body: demo_wrapper('demo-without-ids')
-				}, withoutJs: {
-					name: 'withoutJs',
-					body: demo_wrapper('demo-without-js')
-				}, complex: {
-					name: 'complex',
-					body: demo_wrapper('demo-complex')
-				}, index: {
-					name: 'index',
-					body: all_demos()
-				}
-			});
-
-			var siteConfig = {
-				html: {
-					dependencies: {
-						'bit-docs-tag-demo': 'file://' + __dirname
-					}
-				},
-				dest: temp,
-				debug: !!process.env.npm_config_debug,
-				devBuild: !!process.env.npm_config_devBuild,
-				parent: 'index',
-				forceBuild: true,
-				minifyBuild: false
-			};
-
-			return generate(docMap, siteConfig);
-		});
+	after(function() {
+		ctx.browser.close();
+		server.close();
 	});
 
-	describe('demo widget', function () {
+	describe("demo widget", function() {
 		function basicsWork() {
-			it('exists on page', function () {
-				browser.assert.success();
-				browser.assert.global('PACKAGES');
-				browser.assert.element('.demo_wrapper', 'wrapper exists');
-				browser.assert.element('.demo_wrapper .demo', 'injected into wrapper');
+			it("exists on page", function() {
+				return ctx.page
+					.waitForFunction(function() {
+						return !!window.PACKAGES;
+					})
+					.then(function() {
+						return ctx.page.evaluate(function() {
+							return {
+								hasPackages: !!window.PACKAGES,
+								hasWrapper: !!document.querySelectorAll(".demo_wrapper").length,
+								wasInjected: !!document.querySelectorAll(".demo_wrapper .demo")
+									.length
+							};
+						});
+					})
+					.then(function(r) {
+						assert(r.hasPackages, "has global PACKAGES");
+						assert(r.hasWrapper, "wrapper exists");
+						assert(r.wasInjected, "injected into wrapper");
+					});
 			});
 
-			describe('tabs and contents', function () {
-				it('has three', function () {
-					browser.assert.elements('.tab', 3, 'there are three tabs');
-					browser.assert.elements('.tab-content', 3, 'there are three tab contents');
+			describe("tabs and contents", function() {
+				it("has three", function() {
+					return ctx.page
+						.evaluate(function() {
+							return {
+								tabs: document.querySelectorAll(".tab").length,
+								tabContent: document.querySelectorAll(".tab-content").length
+							};
+						})
+						.then(function(r) {
+							assert.equal(r.tabs, 3, "there are three tabs");
+							assert.equal(r.tabContent, 3, "there are three tab contents");
+						});
 				});
 
-				it('only one active', function () {
-					browser.assert.element('.tab.active', 'only one tab is active');
-					browser.assert.element('.tab-content:not([style*="none"])', 'only one tab content is visible');
+				it("only one active", function() {
+					return ctx.page
+						.evaluate(function() {
+							return {
+								activeTabs: document.querySelectorAll(".tab.active").length,
+								activeTabContent: document.querySelectorAll(
+									'.tab-content:not([style*="none"])'
+								).length
+							};
+						})
+						.then(function(r) {
+							assert.equal(r.activeTabs, 1, "only one tab is active");
+							assert.equal(r.activeTabContent, 1, "only one tab is active");
+						});
 				});
 
-				it('defaults to demo', function () {
-					browser.assert.text('.tab.active', 'Demo', '"Demo" is active tab text');
-					browser.assert.attribute('.tab.active', 'data-tab', 'demo', 'demo is active data-tab');
-					browser.assert.style('[data-for="demo"]', 'display', '', 'demo tab content is visible');
+				it("defaults to demo", function() {
+					return ctx.page
+						.evaluate(function() {
+							var tab = document.querySelector(".tab.active");
+							return {
+								tabText: tab.textContent,
+								tabData: tab.dataset.tab,
+								isVisible:
+									document.querySelector('[data-for="demo"]').style.display ===
+									""
+							};
+						})
+						.then(function(r) {
+							assert.equal(r.tabText, "Demo", "'Demo' is active tab text");
+							assert.equal(r.tabData, "demo", "demo is active data-tab");
+							assert(r.isVisible, "demo tab content is visible");
+						});
 				});
 			});
 
-			describe('clicking HTML tab', function () {
-				before(function () {
-					return browser.click('[data-tab="html"]');
+			describe("clicking HTML tab", function() {
+				before(function() {
+					return ctx.page.click('[data-tab="html"]');
 				});
 
-				it('changes tab and content', function () {
-					browser.assert.attribute('.tab.active', 'data-tab', 'html', 'html is active data-tab');
-					browser.assert.style('[data-for="html"]', 'display', '', 'html tab content is visible');
+				it("changes tab and content", function() {
+					return ctx.page
+						.evaluate(function() {
+							return {
+								activeTab: document.querySelector(".tab.active").dataset.tab,
+								isVisible:
+									document.querySelector('[data-for="html"]').style.display ===
+									""
+							};
+						})
+						.then(function(r) {
+							assert.equal(r.activeTab, "html", "html is active data-tab");
+							assert(r.isVisible, "html tab content is visible");
+						});
 				});
 			});
 		}
 
 		function iframeAssert(path, regex) {
-			describe('iframe (' + path + '.html)', function () {
-				var iframe;
-				var iframeDocument;
+			describe("iframe (" + path + ".html)", function() {
+				it("has correct url and content", function() {
+					return ctx.page
+						.waitForFunction(function() {
+							var iframe = document.querySelector("iframe");
+							var iframeDocument = iframe.contentWindow.document;
 
-				before(function () {
-					iframe = browser.query('iframe');
-					iframeDocument = iframe.contentWindow.document;
-				});
+							return /Hello world/.test(iframeDocument.body.innerHTML);
+						})
+						.then(function() {
+							return ctx.page.evaluate(function() {
+								var iframe = document.querySelector("iframe");
+								var iframeDocument = iframe.contentWindow.document;
 
-				it('has correct url and parent', function () {
-					assert.equal(iframe.src, '../demos/' + path + '.html');
-					assert.equal(iframeDocument.URL, 'http://example.com/test/demos/' + path + '.html');
-					assert.equal(iframe.contentWindow.parent, browser.window.parent);
-				});
+								return {
+									src: iframe.src,
+									url: iframe.contentWindow.document.URL,
+									html: iframeDocument.body.innerHTML
+								};
+							});
+						})
+						.then(function(r) {
+							assert.equal(
+								r.src,
+								"http://127.0.0.1:8081/test/demos/" + path + ".html"
+							);
+							assert.equal(
+								r.url,
+								"http://127.0.0.1:8081/test/demos/" + path + ".html"
+							);
 
-				it('has correct content', function () {
-					assert(/Hello world/.test(iframeDocument.body.innerHTML));
-
-					if (regex instanceof RegExp) {
-						assert(regex.test(iframeDocument.body.innerHTML));
-					}
+							if (regex instanceof RegExp) {
+								assert(regex.test(r.html));
+							}
+						});
 				});
 			});
 		}
 
-		function dataforAssert(selector, strings) {
-			describe('data-for=' + selector, function () {
-				before(function () {
-					if (strings instanceof Array) {
-						strings = strings.join(' ');
-					}
-				});
-
-				it('has correct content', function () {
-					browser.assert.text('[data-for="' + selector + '"] pre', strings);
+		function dataForHtml(strings) {
+			describe("data-for=html", function() {
+				it("has correct content", function() {
+					return ctx.page
+						.evaluate(function() {
+							return document.querySelector("[data-for=html] pre").textContent;
+						})
+						.then(function(text) {
+							var content =
+								strings instanceof Array ? strings.join("") : strings;
+							assert.equal(
+								text
+									.replace("\n", "")
+									.replace(/;\s+/gm, ";")
+									.trim(),
+								content
+							);
+						});
 				});
 			});
 		}
 
-		describe('with ids', function () {
-			before(function () {
-				return browser.visit('/test/temp/withIds.html');
+		function dataForJs(strings) {
+			describe("data-for=js", function() {
+				it("has correct content", function() {
+					return ctx.page
+						.evaluate(function() {
+							return document.querySelector("[data-for=js] pre").textContent;
+						})
+						.then(function(text) {
+							var content =
+								strings instanceof Array ? strings.join("") : strings;
+							assert.equal(
+								text
+									.replace("\n", "")
+									.replace(/;\s+/gm, ";")
+									.trim(),
+								content
+							);
+						});
+				});
+			});
+		}
+
+		describe("with ids", function() {
+			before(function() {
+				return ctx.browser.newPage().then(function(p) {
+					ctx.page = p;
+					return ctx.page.goto("http://127.0.0.1:8081/test/temp/withIds.html");
+				});
 			});
 
-			basicsWork();
-
-			describe('Demo', function () {
-				iframeAssert('demo-with-ids', /it worked/);
+			after(function() {
+				return ctx.page.close().then(function() {
+					ctx.page = null;
+				});
 			});
 
-			describe('HTML', function () {
-				dataforAssert('html', '<b>Hello world!</b>');
+			describe("basics", function() {
+				basicsWork();
 			});
 
-			describe('JS', function () {
-				dataforAssert('js', [
+			describe("Demo", function() {
+				iframeAssert("demo-with-ids", /it worked/);
+			});
+
+			describe("HTML", function() {
+				dataForHtml("<b>Hello world!</b>");
+			});
+
+			describe("JS", function() {
+				dataForJs([
 					'var div = document.createElement("div");',
 					'div.textContent = "it worked!";',
-					'document.body.appendChild(div);'
+					"document.body.appendChild(div);"
 				]);
 			});
 		});
 
-		describe('without ids', function () {
-			before(function () {
-				return browser.visit('/test/temp/withoutIds.html');
+		describe("without ids", function() {
+			before(function() {
+				return ctx.browser.newPage().then(function(p) {
+					ctx.page = p;
+					return ctx.page.goto(
+						"http://127.0.0.1:8081/test/temp/withoutIds.html"
+					);
+				});
+			});
+
+			after(function() {
+				return ctx.page.close().then(function() {
+					ctx.page = null;
+				});
 			});
 
 			basicsWork();
 
-			describe('Demo', function () {
-				iframeAssert('demo-without-ids', /it worked/);
+			describe("Demo", function() {
+				iframeAssert("demo-without-ids", /it worked/);
 			});
 
-			describe('HTML', function () {
-				dataforAssert('html', [
-					'<div><b>Hello world!</b></div>',
-					'<div>it worked!</div>'
+			describe("HTML", function() {
+				dataForHtml([
+					"<div><b>Hello world!</b></div>",
+					"<div>it worked!</div>"
 				]);
 			});
 
-			describe('JS', function () {
-				dataforAssert('js', [
+			describe("JS", function() {
+				dataForJs([
 					'var div = document.createElement("div");',
 					'div.textContent = "it worked!";',
-					'document.body.appendChild(div);'
+					"document.body.appendChild(div);"
 				]);
 			});
 		});
 
-		describe('without js', function () {
-			before(function () {
-				return browser.visit('/test/temp/withoutJs.html');
+		describe("without js", function() {
+			before(function() {
+				return ctx.browser.newPage().then(function(p) {
+					ctx.page = p;
+					return ctx.page.goto(
+						"http://127.0.0.1:8081/test/temp/withoutJs.html"
+					);
+				});
+			});
+
+			after(function() {
+				return ctx.page.close().then(function() {
+					ctx.page = null;
+				});
 			});
 
 			basicsWork();
 
-			describe('Demo', function () {
-				iframeAssert('demo-without-js');
+			describe("Demo", function() {
+				iframeAssert("demo-without-js");
 			});
 
-			describe('HTML', function () {
-				dataforAssert('html', '<b>Hello world!</b>');
+			describe("HTML", function() {
+				dataForHtml("<b>Hello world!</b>");
 			});
 
-			describe('JS', function () {
+			describe("JS", function() {
 				// expect no content
-				dataforAssert('js', '');
+				dataForJs("");
 
-				it('tab is hidden', function () {
-					browser.assert.style('[data-tab="js"]', 'display', 'none', 'js tab is hidden');
+				it("tab is hidden", function() {
+					return ctx.page
+						.evaluate(function() {
+							return document.querySelector('[data-tab="js"]').style.display;
+						})
+						.then(function(display) {
+							assert.equal(display, "none", "js tab is hidden");
+						});
 				});
 			});
 		});
 
-		describe('complex', function () {
+		describe("complex", function() {
 			this.timeout(8000);
 
-			before(function () {
-				return browser.visit('/test/temp/complex.html');
+			before(function() {
+				return ctx.browser
+					.newPage()
+					.then(function(p) {
+						ctx.page = p;
+						return ctx.page.goto(
+							"http://127.0.0.1:8081/test/temp/complex.html"
+						);
+					})
+					.then(function() {
+						return ctx.page.waitForFunction(function() {
+							return !!document.querySelector(".tab.active");
+						});
+					});
+			});
+
+			after(function() {
+				return ctx.page.close().then(function() {
+					ctx.page = null;
+				});
 			});
 
 			basicsWork();
 
-			describe('Demo', function () {
-				iframeAssert('demo-complex');
+			describe("Demo", function() {
+				iframeAssert("demo-complex");
 			});
 
-			describe('HTML', function () {
-				dataforAssert('html', '<em>StealJS should load can-stache, which should appendChild here:</em>');
-			});
-
-			describe('JS', function () {
-				dataforAssert('js', /{{subject}}/);
+			describe("HTML", function() {
+				dataForHtml(
+					"<em>StealJS should load can-stache, which should appendChild here:</em>"
+				);
 			});
 		});
 
-		describe('multiple instances', function () {
+		describe("multiple instances", function() {
 			this.timeout(8000);
 
-			before(function () {
-				return browser.visit('/test/temp/index.html');
+			before(function() {
+				return ctx.browser
+					.newPage()
+					.then(function(p) {
+						ctx.page = p;
+						return ctx.page.goto("http://127.0.0.1:8081/test/temp/index.html");
+					})
+					.then(function() {
+						return ctx.page.waitForFunction(function() {
+							return !!document.querySelector(".tab.active");
+						});
+					});
 			});
 
-			it('exist on page', function () {
-				browser.assert.success();
-				browser.assert.elements('.demo_wrapper', 4, 'four wrappers exists');
-				browser.assert.elements('.demo_wrapper .demo', 4, 'four injected into wrappers');
+			after(function() {
+				return ctx.page.close().then(function() {
+					ctx.page = null;
+				});
 			});
 
-			describe('clicking all HTML tabs', function () {
-				before(function () {
-					var htmlTabs = browser.queryAll('[data-tab="html"]');
-
-					return Promise.all(htmlTabs.map(function (el) {
-						browser.click(el);
-					}));
-				});
-
-				it('changes all tabs and contents', function () {
-					browser.assert.attribute('.tab.active', 'data-tab', 'html', 'html is active data-tab');
-					browser.assert.style('[data-for="html"]', 'display', '', 'html tab content is visible');
-				});
+			it("exist on page", function() {
+				return ctx.page
+					.evaluate(function() {
+						return {
+							wrappers: document.querySelectorAll(".demo_wrapper").length,
+							injected: document.querySelectorAll(".demo_wrapper .demo").length
+						};
+					})
+					.then(function(r) {
+						assert.equal(r.wrappers, 4, "four wrappers exists");
+						assert.equal(r.injected, 4, "four injected into wrappers");
+					});
 			});
 		});
-	});
-
-	after(function () {
-		browser.destroy();
-		server.close();
 	});
 });

--- a/test.js
+++ b/test.js
@@ -12,9 +12,11 @@ describe("bit-docs-tag-demo", function() {
 			server.on("error", reject);
 		});
 
-		var puppeteerPromise = puppeteer.launch().then(function(b) {
-			ctx.browser = b;
-		});
+		var puppeteerPromise = puppeteer
+			.launch({ args: ["--no-sandbox"] })
+			.then(function(b) {
+				ctx.browser = b;
+			});
 
 		return Promise.all([serverPromise, puppeteerPromise]);
 	});

--- a/test/demos/demo-height.html
+++ b/test/demos/demo-height.html
@@ -1,0 +1,9 @@
+<div id="demo-html"></b></div>
+<script id="demo-source">
+	for (var i = 0; i < 7; i += 1) {
+		var div = document.createElement("div");
+		div.style.height = "100px";
+		div.textContent = "it worked!";
+		document.body.appendChild(div);
+	}
+</script>

--- a/test/generate.js
+++ b/test/generate.js
@@ -1,0 +1,69 @@
+var path = require("path");
+var generate = require("bit-docs-generate-html/generate");
+
+function makeWrapper(path) {
+	return (
+		'<div class="demo_wrapper" data-demo-src="demos/' +
+		path +
+		'.html"></div>' +
+		"\n"
+	);
+}
+
+function allDemos() {
+	return [
+		"demo-with-ids",
+		"demo-without-ids",
+		"demo-without-js",
+		"demo-complex"
+	]
+		.map(function(demo) {
+			return "<h2>" + demo + "</h2>" + makeWrapper(demo);
+		})
+		.join("<br>");
+}
+
+var docMap = Promise.resolve({
+	withIds: {
+		name: "withIds",
+		body: makeWrapper("demo-with-ids")
+	},
+	withoutIds: {
+		name: "withoutIds",
+		body: makeWrapper("demo-without-ids")
+	},
+	withoutJs: {
+		name: "withoutJs",
+		body: makeWrapper("demo-without-js")
+	},
+	complex: {
+		name: "complex",
+		body: makeWrapper("demo-complex")
+	},
+	index: {
+		name: "index",
+		body: allDemos()
+	}
+});
+
+var siteConfig = {
+	html: {
+		dependencies: {
+			"bit-docs-tag-demo": "file://" + path.join(__dirname, "..")
+		}
+	},
+	dest: path.join(__dirname, "temp"),
+	debug: !!process.env.npm_config_debug,
+	devBuild: !!process.env.npm_config_devBuild,
+	parent: "index",
+	forceBuild: true,
+	minifyBuild: false
+};
+
+generate(docMap, siteConfig)
+	.then(function() {
+		console.log("DONE!");
+	})
+	.catch(function(e) {
+		console.log("FAILED: \n", e);
+	});

--- a/test/generate.js
+++ b/test/generate.js
@@ -15,7 +15,8 @@ function allDemos() {
 		"demo-with-ids",
 		"demo-without-ids",
 		"demo-without-js",
-		"demo-complex"
+		"demo-complex",
+		"demo-height"
 	]
 		.map(function(demo) {
 			return "<h2>" + demo + "</h2>" + makeWrapper(demo);
@@ -39,6 +40,10 @@ var docMap = Promise.resolve({
 	complex: {
 		name: "complex",
 		body: makeWrapper("demo-complex")
+	},
+	height: {
+		name: "height",
+		body: makeWrapper("demo-height")
 	},
 	index: {
 		name: "index",


### PR DESCRIPTION
A couple of issues:

- The resize logic in https://github.com/bit-docs/bit-docs-tag-demo/pull/5 causes the iframe to shrink on each timeout lapse

![kapture 2018-01-08 at 16 13 03](https://user-images.githubusercontent.com/724877/34745967-96bd7472-f54f-11e7-9571-b0dfd8905649.gif)

- With the resize logic in place, the tests existing tests break because `iframe.contentWindow.document.body.scrollHeight` is undefined in zombie

What I did here:

- Push the indentation fixes in its own commit https://github.com/bit-docs/bit-docs-tag-demo/commit/f389dea4ea39fbb1ccf8de86efbf21479a7760ff
- Refactor the tests to use puppeteer instead of zombie (tried to get it to work with the steal-qunit/iframe combo we use in other places but could not get it to work) https://github.com/bit-docs/bit-docs-tag-demo/commit/e7f3fc47c528a836ba03451f664b3735f4b43f3c
- Modified resizeIframe function to prevent setting the height if value within a tolerance range https://github.com/bit-docs/bit-docs-tag-demo/pull/13/commits/9d662f3910a717517410c444e41be1af7a5159c2


  