### PR TITLE
Resize iframe logic should account for padding

### DIFF
--- a/test.js
+++ b/test.js
@@ -388,6 +388,34 @@ describe("bit-docs-tag-demo", function() {
 			});
 		});
 
+		describe("resize iframe logic adds up border/padding/margin", function() {
+			before(function() {
+				return ctx.browser
+					.newPage()
+					.then(function(p) {
+						ctx.page = p;
+						return ctx.page.goto("http://127.0.0.1:8081/test/temp/heightBoxModel.html");
+					})
+					.then(function() {
+						return ctx.page.waitForFunction(function() {
+							var iframe = document.querySelector("iframe");
+							return iframe && iframe.style.height === "600px";
+						});
+					});
+			});
+
+			it("resizes height up to 600px", function() {
+				ctx.page
+					.evaluate(function() {
+						return document.querySelector("iframe").style.height;
+					})
+					.then(function(height) {
+						assert.equal(height, "600px");
+					});
+			});
+		});
+
+
 		describe("multiple instances", function() {
 			this.timeout(8000);
 
@@ -420,8 +448,8 @@ describe("bit-docs-tag-demo", function() {
 						};
 					})
 					.then(function(r) {
-						assert.equal(r.wrappers, 5, "four wrappers exists");
-						assert.equal(r.injected, 5, "four injected into wrappers");
+						assert.equal(r.wrappers, 6, "four wrappers exists");
+						assert.equal(r.injected, 6, "four injected into wrappers");
 					});
 			});
 		});

--- a/test/demos/demo-height-box-model.html
+++ b/test/demos/demo-height-box-model.html
@@ -1,0 +1,12 @@
+<div id="demo-html"></div>
+<script id="demo-source">
+	for (var i = 0; i < 5; i += 1) {
+		var div = document.createElement("div");
+		div.style.height = "100px";
+		div.textContent = "100px";
+		document.body.appendChild(div);
+	}
+	var frame = window.frameElement;
+	frame.style.paddingTop = "100px";
+	frame.style.paddingBottom = "100px";
+</script>

--- a/test/generate.js
+++ b/test/generate.js
@@ -16,7 +16,8 @@ function allDemos() {
 		"demo-without-ids",
 		"demo-without-js",
 		"demo-complex",
-		"demo-height"
+		"demo-height",
+		"demo-height-box-model"
 	]
 		.map(function(demo) {
 			return "<h2>" + demo + "</h2>" + makeWrapper(demo);
@@ -44,6 +45,10 @@ var docMap = Promise.resolve({
 	height: {
 		name: "height",
 		body: makeWrapper("demo-height")
+	},
+	heightBoxModel: {
+		name: "heightBoxModel",
+		body: makeWrapper("demo-height-box-model")
 	},
 	index: {
 		name: "index",


### PR DESCRIPTION
Closes canjs/3858

@justinbmeyer  the issue was that the CanJS website adds padding and border to the iframe and that should be accounted for the final height value of the iframe.

This version works better:

![screen shot 2018-01-24 at 4 29 34 pm](https://user-images.githubusercontent.com/724877/35363659-485fc732-0128-11e8-991d-7445d5c34fe8.png)
![screen shot 2018-01-24 at 4 43 57 pm](https://user-images.githubusercontent.com/724877/35363660-48730338-0128-11e8-8a94-ee44c967e262.png)
![screen shot 2018-01-24 at 4 44 08 pm](https://user-images.githubusercontent.com/724877/35363661-4887127e-0128-11e8-9c98-b7c4047f82c8.png)
![screen shot 2018-01-24 at 4 47 43 pm](https://user-images.githubusercontent.com/724877/35363662-489b7ae8-0128-11e8-8192-7063026f0f8c.png)
![screen shot 2018-01-24 at 4 47 52 pm](https://user-images.githubusercontent.com/724877/35363663-48ae2d96-0128-11e8-912f-d1fdf2d7d974.png)
