### PR TITLE
Fix code copy button

### DIFF
--- a/demo_frame.js
+++ b/demo_frame.js
@@ -31,7 +31,9 @@ module.exports = function(node) {
 		var js = getJS.call(this, sourceEl);
 
 		if (html && html.trim()) {
-			var dataForHtml = node.querySelector("[data-for=html] > pre code, [data-for=html] > div > pre code");
+			var htmlPre = node.querySelector('[data-for=html] > pre, [data-for=html] > div > pre');
+			var dataForHtml = document.createElement('code');
+			htmlPre.appendChild(dataForHtml);
 			dataForHtml.innerHTML = escape(html);
 			prettify(dataForHtml);
 
@@ -39,7 +41,9 @@ module.exports = function(node) {
 		}
 
 		if (js) {
-			var dataForJS = node.querySelector("[data-for=js] > pre code, [data-for=js] > div > pre code");
+			var jsPre = node.querySelector('[data-for=js] > pre, [data-for=js] > div > pre');
+			var dataForJS = document.createElement('code');
+			jsPre.appendChild(dataForJS);
 			dataForJS.innerHTML = escape(js);
 			prettify(dataForJS);
 

--- a/demo_tpl.js
+++ b/demo_tpl.js
@@ -1,6 +1,7 @@
-// Note that the space in the <code> </code> blocks is significant:
-// without it, any demo in a page would break the rest of the code
-// examples throughout the page.
+// Leaving the content the of the <pre> empty is significant
+// <code> element will be appended when processing the code highlighting
+// this prevent PrismJS to register "Copy" button for demos at bit-docs-prettify step
+
 
 module.exports = `
 	<ul>
@@ -12,9 +13,9 @@ module.exports = `
 		<iframe></iframe>
 	</div>
 	<div class="tab-content" data-for="html">
-		<pre class="line-numbers language-html"><code> </code></pre>
+		<pre class="line-numbers language-html"></pre>
 	</div>
 	<div class="tab-content" data-for="js">
-		<pre class="line-numbers language-js"><code> </code></pre>
+		<pre class="line-numbers language-js"></pre>
 	</div>
 `;

--- a/test.js
+++ b/test.js
@@ -507,5 +507,45 @@ describe("bit-docs-tag-demo", function() {
 					});
 			});
 		});
+
+		describe("Insert code tag", function() {
+			insertCodeFor("html");
+			insertCodeFor("js");
+
+			function insertCodeFor(htmlOrJs) {
+				var tab = htmlOrJs === "html" ? "withoutJs" : "withoutHtml";
+				describe(htmlOrJs, function(){
+					
+					before(function() {
+						return ctx.browser.newPage().then(function(p) {
+							ctx.page = p;
+							return ctx.page.goto(
+								"http://127.0.0.1:8081/test/temp/" + tab + ".html"
+							);
+						}).then(function() {
+							return ctx.page.waitForFunction(function() {
+								return !!document.querySelector(".tab.active");
+							});
+						});
+					});
+	
+					after(function() {
+						return ctx.page.close().then(function() {
+							ctx.page = null;
+						});
+					});
+	
+					it("inserts " + htmlOrJs + " code", function() {
+						return ctx.page.evaluate(function(htmlOrJs){
+								return {
+									code: document.querySelector("[data-for=" + htmlOrJs + "] > pre"),
+								}
+							}, htmlOrJs).then(function(r){
+								assert.ok(r.code, "Code inserted at the right spot");
+							})
+					});
+				});
+			}
+		});
 	});
 });


### PR DESCRIPTION
Fixes "Copy" button which copies empty string.

The issue is that a copy button for each demo gets registered in the `bit-docs-prettify` step when the demos code is empty

### The logic behind the changes

1. Update the template in the `demo_tpl.js` to have empty `<pre>` element
2. Update the `process` function in the `demo_frame.js` by creating a `<code>` element, setting its `innerHTML` and append it to `<pre>`

Like this `Copy` button will be registered at the right time instead of during `bit-docs-prettify` step.

Fixes https://github.com/canjs/canjs/issues/5126
